### PR TITLE
Fix overflow issue that will cause pixel with value 255 to round to 0.

### DIFF
--- a/Samples/Utils/Resize.cu
+++ b/Samples/Utils/Resize.cu
@@ -26,7 +26,7 @@ static __global__ void Resize(cudaTextureObject_t texY, cudaTextureObject_t texU
 
     int x = ix * 2, y = iy * 2;
     typedef decltype(YuvUnitx2::x) YuvUnit;
-    const int MAX = 1 << (sizeof(YuvUnit) * 8);
+    const int MAX = (1 << (sizeof(YuvUnit) * 8)) - 1;
     *(YuvUnitx2 *)(pDst + y * nPitch + x * sizeof(YuvUnit)) = YuvUnitx2 {
         (YuvUnit)(tex2D<float>(texY, x / fxScale, y / fyScale) * MAX),
         (YuvUnit)(tex2D<float>(texY, (x + 1) / fxScale, y / fyScale) * MAX)


### PR DESCRIPTION
E.g. maxvalue of 8bit number is 255 not 256.